### PR TITLE
Added support for unbound.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ More features utilized with an expanded syntax:
 unbound [FROM] {
     except IGNORED_NAMES...
     option NAME VALUE
+    config FILENAME
 }
 ~~~
 
@@ -40,6 +41,9 @@ unbound [FROM] {
 * **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from resolving.
 * `option` allows setting *some* unbound options (see unbound.conf(5)), this can be specified multiple
   times.
+* `config` allows one to supply an `unbound.conf` file to configure unbound.
+  _Note:_ The unbound configuration file still needs to be populated inside a
+  docker container.
 
 ## Metrics
 

--- a/setup.go
+++ b/setup.go
@@ -49,6 +49,7 @@ func unboundParse(c *caddy.Controller) (*Unbound, error) {
 
 	i := 0
 	for c.Next() {
+		// Return an error if unbound block specified more than once
 		if i > 0 {
 			return nil, plugin.ErrOnce
 		}
@@ -64,6 +65,9 @@ func unboundParse(c *caddy.Controller) (*Unbound, error) {
 		}
 
 		for c.NextBlock() {
+			var args []string
+			var err error
+
 			switch c.Val() {
 			case "except":
 				except := c.RemainingArgs()
@@ -75,11 +79,19 @@ func unboundParse(c *caddy.Controller) (*Unbound, error) {
 				}
 				u.except = except
 			case "option":
-				args := c.RemainingArgs()
+				args = c.RemainingArgs()
 				if len(args) != 2 {
 					return nil, c.ArgErr()
 				}
-				if err := u.setOption(args[0], args[1]); err != nil {
+				if err = u.setOption(args[0], args[1]); err != nil {
+					return nil, err
+				}
+			case "config":
+				args = c.RemainingArgs()
+				if len(args) != 1 {
+					return nil, c.ArgErr()
+				}
+				if err = u.config(args[0]); err != nil {
 					return nil, err
 				}
 			default:

--- a/unbound.go
+++ b/unbound.go
@@ -70,6 +70,22 @@ func (u *Unbound) setOption(k, v string) error {
 	return nil
 }
 
+// config reads the file f and sets unbound configuration
+func (u *Unbound) config(f string) error {
+	var err error
+
+	err = u.u.Config(f)
+	if err != nil {
+		return fmt.Errorf("failed to read config file (%s) UDP context: %s", f, err)
+	}
+
+	err = u.t.Config(f)
+	if err != nil {
+		return fmt.Errorf("failed to read config file (%s) TCP context: %s", f, err)
+	}
+	return nil
+}
+
 // ServeDNS implements the plugin.Handler interface.
 func (u *Unbound) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}


### PR DESCRIPTION
Adding support for setting values that can not be set pragmatically. The config option allows one to use the configuration file interface and supply a much more complex configuration.